### PR TITLE
Fixes and enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+core*
+config.json
+venv/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # zellostream
 Python scripts to stream audio one way to a Zello channel.  Designed for Python 3.X
 
-Two scripts are provided.  zellostream.py acquires audio from a sound card to send to Zello.  zellostreamUDP.py acquires audio from a UDP socket (intended for use with trunk-recorder and the [simplestream plugin](https://github.com/robotastic/trunk-recorder/blob/master/docs/CONFIGURE.md#simplestream-plugin)).  
+Two scripts are provided.  zellostream.py acquires audio from a sound card to send to Zello.  zellostreamUDP.py acquires audio from a UDP socket (intended for use with trunk-recorder and the [simplestream plugin](https://github.com/robotastic/trunk-recorder/blob/master/docs/CONFIGURE.md#simplestream-plugin)).
 
-Create a developer account with Zello to get credentials.  Set up a different account than what you normally use for Zello, as trying to use this script with the same account that you're using on your mobile device will cause problems.  
+Create a developer account with Zello to get credentials.  Set up a different account than what you normally use for Zello, as trying to use this script with the same account that you're using on your mobile device will cause problems.
 
 For Zello consumer network:
 - Go to https://developers.zello.com/ and click Login
@@ -20,12 +20,15 @@ For Zello consumer network:
 - password:  Zello account password to use for streaming
 - zello_channel:  name of the zello channel to stream to
 - issuer:  Issuer credential from Zello account (see above)
-- vox_silence_time:  Time in seconds of detected silence before streaming stops
-- audio_threshold:  Audio detected above this level will be streamed
-- input_device_index:  Index of the audio input device to use for streaming (not used in zellostreamUDP.py)
-- TGID_in_stream: When true, a four-byte talkgroup ID is expected prior to the audio data in each incoming UDP packet and only the talkgroup specified in TGID_to_play will be streamed.  Default is false.  (only used in zellostreamUDP.py)
-- TGID_to_play: When TGID_in_stream is set to true, the integer in this field specifies which talkgroup ID will be streamed (only used in zellostreamUDP.py)
-- UDP_PORT: UDP port to listen for oncompressed PCM audio on.  Audio received on this port will be compressed and streamed to Zello (only used in zeelostreamUDP.py)
+- vox_silence_time:  Time in seconds of detected silence before streaming stops. Default: 3
+- audio_threshold:  Audio detected above this level will be streamed. Default: 1000
+- input_device_index:  Index of the audio input device to use for streaming (not used in zellostreamUDP.py). Use list_devices.py to find the right index. Default 0
+- TGID_in_stream: When true, a four-byte talkgroup ID is expected prior to the audio data in each incoming UDP packet and only the talkgroup specified in TGID_to_play will be streamed.  Default is false.  (only used in zellostreamUDP.py).
+- TGID_to_play: When TGID_in_stream is set to true, the integer in this field specifies which talkgroup ID will be streamed (only used in zellostreamUDP.py). Default 70000
+- UDP_PORT: UDP port to listen for oncompressed PCM audio on.  Audio received on this port will be compressed and streamed to Zello (only used in zeelostreamUDP.py). Default 9123
+- audio_sample_rate: Sample rate of the audio device (samples per seconds). Default: 48000
+- zello_sample_rate: Sample rate of the stream sent to Zello (samples per seconds). Default: 16000
+- in_channel_config: Channel to send. "mono" for mono device. "left" or "right" for stereo device. Default: mono
 
 ## Dependencies
 On Windows, requires these DLL files in the same directory:
@@ -41,10 +44,10 @@ Requires pyaudio:
 https://people.csail.mit.edu/hubert/pyaudio/
 
 ## Using zellostreamUDP.py with trunk-recorder
-The [simplestream plugin](https://github.com/robotastic/trunk-recorder/blob/master/docs/CONFIGURE.md#simplestream-plugin) of trunk-recorder can be be used to send audio from trunk-recorder in real time, as it is being recorded.  zellostreamUDP.py can receive this audio and stream it to Zello with low latency.  
+The [simplestream plugin](https://github.com/robotastic/trunk-recorder/blob/master/docs/CONFIGURE.md#simplestream-plugin) of trunk-recorder can be be used to send audio from trunk-recorder in real time, as it is being recorded.  zellostreamUDP.py can receive this audio and stream it to Zello with low latency.
 
-zellostreamUDP.py sends audio to zello in the order recieved via UDP packets with no mixing or delays.  Therefore, only a single talkgroup should be sent to Zello using this method.  If audio from more than one talkgroup is sent and both are active at the same time, the audio from the two talkgroups will be interleaved and unintelligible.  
+zellostreamUDP.py sends audio to zello in the order recieved via UDP packets with no mixing or delays.  Therefore, only a single talkgroup should be sent to Zello using this method.  If audio from more than one talkgroup is sent and both are active at the same time, the audio from the two talkgroups will be interleaved and unintelligible.
 
 A single talkgroup can be streamed in one of two ways:
-- Configure the trunk-recorder simplestream plugin to only send audio from a single talkgroup with the "sendTGID" parameter set to false in the simplestream configuration.  In the zellostreamUDP.py config.json file, set TGID_in_stream to false.  
-- Configure the trunk-recorder simplesstream plugin to send audio from multiple talkgroups with the "sendTGID" parameter set to true in the simplestream configuration.  In the zellostreamUDP.py config.json file, set TGID_in_stream to true and TGID_to_play to the desired talkgroup ID to stream.  
+- Configure the trunk-recorder simplestream plugin to only send audio from a single talkgroup with the "sendTGID" parameter set to false in the simplestream configuration.  In the zellostreamUDP.py config.json file, set TGID_in_stream to false.
+- Configure the trunk-recorder simplesstream plugin to send audio from multiple talkgroups with the "sendTGID" parameter set to true in the simplestream configuration.  In the zellostreamUDP.py config.json file, set TGID_in_stream to true and TGID_to_play to the desired talkgroup ID to stream.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ For Zello consumer network:
 - TGID_to_play: When TGID_in_stream is set to true, the integer in this field specifies which talkgroup ID will be streamed (only used in zellostreamUDP.py). Default 70000
 - UDP_PORT: UDP port to listen for oncompressed PCM audio on.  Audio received on this port will be compressed and streamed to Zello (only used in zeelostreamUDP.py). Default 9123
 - audio_sample_rate: Sample rate of the audio device (samples per seconds). Default: 48000
+- audio_channels: Number of audio channels in the device. 1 for mono, 2 for stereo. Default 1
 - zello_sample_rate: Sample rate of the stream sent to Zello (samples per seconds). Default: 16000
-- in_channel_config: Channel to send. "mono" for mono device. "left" or "right" for stereo device. Default: mono
+- in_channel_config: Channel to send. "mono" for mono device. "left", "right" or "mix" for stereo device. Default: mono
 
 ## Dependencies
 On Windows, requires these DLL files in the same directory:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-numpy==1.20.1
+numpy
+librosa
 opuslib==3.0.1
 PyAudio==0.2.11
 pycryptodome==3.12.0

--- a/sampleconfig.json
+++ b/sampleconfig.json
@@ -10,6 +10,7 @@
     "TGID_to_play": 58917,
     "UDP_PORT": 9123,
     "audio_sample_rate": 8000,
+    "audio_channels": 1,
     "zello_sample_rate": 16000,
     "in_channel_config": "left"
 }

--- a/sampleconfig.json
+++ b/sampleconfig.json
@@ -1,13 +1,15 @@
 {
-"username":"my_username",
-"password":"my_password",
-"zello_channel":"My_Channel",
-"issuer":"WkM6YWFrbml0dDI6MQ==.nABE/ksSAMPLEDATAHEREj6IXyUCvPisYkDAzaqeMA/WE=",
-"vox_silence_time":2,
-"audio_threshold":700,
-"input_device_index":0,
-"TGID_in_stream": true,
-"TGID_to_play": 58917,
-"UDP_PORT": 9123,
-"audio_sample_rate":8000
+    "username": "my_username",
+    "password": "my_password",
+    "zello_channel": "My_Channel",
+    "issuer": "WkM6YWFrbml0dDI6MQ==.nABE/ksSAMPLEDATAHEREj6IXyUCvPisYkDAzaqeMA/WE=",
+    "vox_silence_time": 2,
+    "audio_threshold": 700,
+    "input_device_index": 0,
+    "TGID_in_stream": true,
+    "TGID_to_play": 58917,
+    "UDP_PORT": 9123,
+    "audio_sample_rate": 8000,
+    "zello_sample_rate": 16000,
+    "in_channel_config": "left"
 }

--- a/zellostream.py
+++ b/zellostream.py
@@ -2,189 +2,277 @@ import websocket
 import json
 import time
 import pyaudio
-from numpy import short, frombuffer, array
+import numpy as np
+import librosa
 import opuslib
 from Crypto.PublicKey import RSA
 from Crypto.Signature import pkcs1_15
 from Crypto.Hash import SHA256
 import base64
 
-'''On Windows, requires these DLL files in the same directory:
+"""On Windows, requires these DLL files in the same directory:
 opus.dll (renamed from libopus-0.dll)
 libwinpthread-1.dll
 libgcc_s_sjlj-1.dll
 These can be obtained from the 'opusfile' download at http://opus-codec.org/downloads/
-'''
+"""
 
-f = open('privatekey.pem','r')
+f = open("privatekey.pem", "r")
 key = RSA.import_key(f.read())
 f.close()
 
-with open('config.json') as f:
-	configdata = json.load(f)
+with open("config.json") as f:
+    configdata = json.load(f)
 
-try:
-	username = configdata['username']
-except:
-	print("ERROR GETTING USERNAME FROM CONFIG FILE")
-try:
-	password = configdata['password']
-except:
-	print("ERROR GETTING PASSWORD FROM CONFIG FILE")
-try:
-	vox_silence_time = configdata['vox_silence_time']
-except:
-	vox_silence_time = 3
-try:
-	in_channel_config = configdata['in_channel']
-except:
-	in_channel_config = 'mono'
-try:
-	issuer = configdata['issuer']
-except:
-	print("ERROR GETTING ZELLO ISSUER ID FROM CONFIG FILE")
-try:
-	zello_channel = configdata['zello_channel']
-except:
-	print("ERROR GETTING ZELLO CHANNEL NAME FROM CONFIG FILE")
-try: 
-	audio_threshold = configdata['audio_threshold']
-except:
-	audio_threshold = 1000
-try:
-	input_device_index = configdata['input_device_index']
-except:
-	input_device_index = 0
+username = configdata.get("username")
+if not username:
+    print("ERROR GETTING USERNAME FROM CONFIG FILE")
+password = configdata.get("password")
+if not password:
+    print("ERROR GETTING PASSWORD FROM CONFIG FILE")
+vox_silence_time = configdata.get("vox_silence_time", 3)
+in_channel_config = configdata.get("in_channel", "mono")
+issuer = configdata.get("issuer")
+if not issuer:
+    print("ERROR GETTING ZELLO ISSUER ID FROM CONFIG FILE")
+zello_channel = configdata.get("zello_channel")
+if not zello_channel:
+    print("ERROR GETTING ZELLO CHANNEL NAME FROM CONFIG FILE")
+audio_threshold = configdata.get("audio_threshold", 1000)
+input_device_index = configdata.get("input_device_index", 0)
+audio_sample_rate = configdata.get("audio_sample_rate", 48000)
+zello_sample_rate = configdata.get("audio_sample_rate", 16000)
+
 
 def create_zello_jwt():
-	#Create a Zello-specific JWT.  Can't use PyJWT because Zello doesn't support url safe base64 encoding in the JWT.
-	header = {"typ": "JWT", "alg": "RS256"}
-	payload = {"iss": issuer,"exp": round(time.time()+60)}
-	signer = pkcs1_15.new(key)
-	json_header = json.dumps(header, separators=(",", ":"), cls=None).encode("utf-8")
-	json_payload = json.dumps(payload, separators=(",",":"), cls=None).encode("utf-8")
-	h = SHA256.new(base64.standard_b64encode(json_header) + b"." + base64.standard_b64encode(json_payload))
-	signature = signer.sign(h)
-	jwt = (base64.standard_b64encode(json_header) + b"." + base64.standard_b64encode(json_payload) + b"." + base64.standard_b64encode(signature))
-	return jwt
+    # Create a Zello-specific JWT.  Can't use PyJWT because Zello doesn't support url safe base64 encoding in the JWT.
+    header = {"typ": "JWT", "alg": "RS256"}
+    payload = {"iss": issuer, "exp": round(time.time() + 60)}
+    signer = pkcs1_15.new(key)
+    json_header = json.dumps(header, separators=(",", ":"), cls=None).encode("utf-8")
+    json_payload = json.dumps(payload, separators=(",", ":"), cls=None).encode("utf-8")
+    h = SHA256.new(
+        base64.standard_b64encode(json_header)
+        + b"."
+        + base64.standard_b64encode(json_payload)
+    )
+    signature = signer.sign(h)
+    jwt = (
+        base64.standard_b64encode(json_header)
+        + b"."
+        + base64.standard_b64encode(json_payload)
+        + b"."
+        + base64.standard_b64encode(signature)
+    )
+    return jwt
+
 
 def EscapeAll(inbytes):
-	if type(inbytes) == str:
-		return inbytes
-	else:
-		return 'b\'{}\''.format(''.join('\\x{:02x}'.format(b) for b in inbytes))
+    if type(inbytes) == str:
+        return inbytes
+    else:
+        return "b'{}'".format("".join("\\x{:02x}".format(b) for b in inbytes))
 
+
+print("Start PyAudio")
 p = pyaudio.PyAudio()
-chunk = 960
+audio_chunk = int(audio_sample_rate * 0.06) # 60ms = 960 samples @ 16000 S/s
+zello_chunk = int(zello_sample_rate * 0.06)
 FORMAT = pyaudio.paInt16
 CHANNELS = 1
-RATE = 16000
-stream = p.open(format = FORMAT,
-	channels = CHANNELS,
-	rate = RATE,
-	input = True,
-	output = True,
-	frames_per_buffer = chunk,
-	input_device_index = input_device_index,)
+print("Open audio")
+stream = p.open(
+    format=FORMAT,
+    channels=CHANNELS,
+    rate=audio_sample_rate,
+    input=True,
+    output=True,
+    frames_per_buffer=audio_chunk,
+    input_device_index=input_device_index,
+)
+print("Audio opened")
 
-def record(seconds,channel='mono'):
-	alldata = bytearray()
-	for i in range(0, int(RATE / chunk * seconds)):
-				data = stream.read(chunk)
-				alldata.extend(data)
-	data  = frombuffer(alldata, dtype=short)
-	if channel == 'left':
-		data = data[0::2]
-	elif channel == 'right':
-		data = data[1::2]
-	else:
-		data = data
-	return data
+
+def record(seconds, channel="mono"):
+    alldata = bytearray()
+    for i in range(0, int(audio_sample_rate / audio_chunk * seconds)):
+        data = stream.read(audio_chunk)
+        alldata.extend(data)
+    data = np.frombuffer(alldata, dtype=np.short)
+    if audio_sample_rate != zello_sample_rate:
+        zello_data = librosa.resample(data, audio_sample_rate, zello_sample_rate)
+    else:
+        zello_data = data
+    if channel == "left":
+        zello_data = zello_data[0::2]
+    elif channel == "right":
+        zello_data = zello_data[1::2]
+    else:
+        zello_data = zello_data
+    return zello_data
+
 
 seq_num = 0
+
+
 def create_zello_connection():
-	ws = websocket.create_connection("wss://zello.io/ws")
-	ws.settimeout(1)
-	global seq_num
-	seq_num = 1
-	send = {}
-	send['command'] = 'logon'
-	send['seq'] = seq_num
-	encoded_jwt = create_zello_jwt()
-	send['auth_token'] = encoded_jwt.decode('utf-8')
-	send['username'] = username
-	send['password'] = password
-	send['channel'] = zello_channel
-	ws.send(json.dumps(send))
-	result = ws.recv()
-	data = json.loads(result)
-	seq_num = seq_num + 1
-	return ws
+    try:
+        ws = websocket.create_connection("wss://zello.io/ws")
+        ws.settimeout(1)
+        global seq_num
+        seq_num = 1
+        send = {}
+        send["command"] = "logon"
+        send["seq"] = seq_num
+        encoded_jwt = create_zello_jwt()
+        send["auth_token"] = encoded_jwt.decode("utf-8")
+        send["username"] = username
+        send["password"] = password
+        send["channel"] = zello_channel
+        ws.send(json.dumps(send))
+        result = ws.recv()
+        data = json.loads(result)
+        print("create_zello_connection: seq:", data.get("seq"))
+        seq_num = seq_num + 1
+        return ws
+    except Exception as ex:
+        print(f"create_zello_connection: exception: {ex}")
+        return None
+
 
 def start_stream(ws):
-	global seq_num
-	send = {}
-	send['command'] = 'start_stream'
-	send['seq'] = seq_num
-	seq_num = seq_num + 1
-	send['type'] = "audio"
-	send['codec'] = "opus"
-	#codec_header:
-	#base64 encoded 4 byte string: first 2 bytes for sample rate, 3rd for number of frames per packet (1 or 2), 4th for the frame size
-	#gd4BPA==  => 0x80 0x3e 0x01 0x3c  => 16000 Hz, 1 frame per packet, 60 ms frame size
-	send['codec_header'] = "gD4BPA=="
-	send['packet_duration'] = 60
-	ws.send(json.dumps(send))
-	data = {}
-	while 'stream_id' not in data.keys():
-		result = ws.recv()
-		data = json.loads(result)
-		print(data)
-		if 'error' in data.keys():
-			if data['error'] == 'channel is not ready':
-				send['seq'] = seq_num
-				seq_num = seq_num + 1
-				ws.send(json.dumps(send))
-	stream_id = int(data['stream_id'])
-	return stream_id
+    global seq_num
+    send = {}
+    send["command"] = "start_stream"
+    send["channel"] = zello_channel
+    send["seq"] = seq_num
+    seq_num = seq_num + 1
+    send["type"] = "audio"
+    send["codec"] = "opus"
+    # codec_header:
+    # base64 encoded 4 byte string: first 2 bytes for sample rate, 3rd for number of frames per packet (1 or 2), 4th for the frame size
+    # gd4BPA==  => 0x80 0x3e 0x01 0x3c  => 16000 Hz, 1 frame per packet, 60 ms frame size
+    frames_per_packet = 1
+    packet_duration = 60
+    codec_header = base64.b64encode(zello_sample_rate.to_bytes(2, "little") + frames_per_packet.to_bytes(1, "big") + packet_duration.to_bytes(1, "big")).decode()
+    send["codec_header"] = codec_header
+    send["packet_duration"] = packet_duration
+    try:
+        ws.send(json.dumps(send))
+    except Exception as ex:
+        print(f"start_stream: send exception {ex}")
+    while True:
+        try:
+            result = ws.recv()
+            data = json.loads(result)
+            print("start_stream: data:", data)
+            if "error" in data.keys():
+                print("start_stream: error", data["error"])
+                if seq_num > 10:
+                    print("start_stream: bailing out")
+                    return None
+                time.sleep(0.5)
+                send["seq"] = seq_num
+                seq_num = seq_num + 1
+                ws.send(json.dumps(send))
+            if "stream_id" in data.keys():
+                stream_id = int(data["stream_id"])
+                return stream_id
+        except Exception as ex:
+            print(f"start_stream: exception {ex}")
+            if seq_num > 10:
+                print("start_stream: bailing out")
+                return None
+            time.sleep(0.5)
+            send["seq"] = seq_num
+            seq_num = seq_num + 1
+            try:
+                ws.send(json.dumps(send))
+            except Exception as ex:
+                print(f"start_stream: send exception {ex}")
+                return None
 
-def stop_stream(ws,stream_id):
-	send = {}
-	send['command'] = 'stop_stream'
-	send['stream_id'] = stream_id
-	ws.send(json.dumps(send))
 
-start_time = time.time()
-packet_id = 0
+def stop_stream(ws, stream_id):
+    try:
+        send = {}
+        send["command"] = "stop_stream"
+        send["stream_id"] = stream_id
+        ws.send(json.dumps(send))
+    except Exception as ex:
+        print(f"stop_stream: exception: {ex}")
 
-enc = opuslib.api.encoder.create_state(RATE,CHANNELS,opuslib.APPLICATION_AUDIO)
-while True:
-	data = record(.06)
-	max_audio_level = max(abs(data))
-	if max_audio_level > audio_threshold:
-		zello_ws = create_zello_connection()
-		stream_id = start_stream(zello_ws)
-		print("sending to stream_id " + str(stream_id))
-		quiet_samples = 0
-		while (quiet_samples < (vox_silence_time*(1/.06))):
-			data2 = data.tobytes()
-			out = opuslib.api.encoder.encode(enc, data2, chunk, len(data2)*2)
-			send_data = bytearray(array([1]).astype('>u1').tobytes())
-			send_data = send_data + array([stream_id]).astype('>u4').tobytes()
-			send_data = send_data + array([packet_id]).astype('>u4').tobytes()  #packet ID is only used in server to client - populate with zeros for client to server direction
-			send_data = send_data + out
-			try:
-				zello_ws.send_binary(send_data)
-			except:
-				break
-			data = record(.06)
-			if abs(max(data)) < audio_threshold:
-				quiet_samples = quiet_samples+1
-			else:
-				quiet_samples = 0
-		print("Done sending audio")
-		stop_stream(zello_ws,stream_id)
-		zello_ws.close()
 
+enc = opuslib.api.encoder.create_state(
+    zello_sample_rate, CHANNELS, opuslib.APPLICATION_AUDIO
+)
+
+stream_id = None
+processing = True
+
+while processing:
+    try:
+        data = record(seconds=0.06, channel=in_channel_config)
+        max_audio_level = max(abs(data))
+        # print(f"Init max_audio_level: {max_audio_level}")
+        if max_audio_level > audio_threshold:
+            print("Audio on")
+            zello_ws = create_zello_connection()
+            if not zello_ws:
+                print("Cannot establish connection")
+                time.sleep(1)
+                continue
+            stream_id = start_stream(zello_ws)
+            if not stream_id:
+                print("Cannot start stream")
+                time.sleep(1)
+                continue
+            print("sending to stream_id " + str(stream_id))
+            packet_id = 0 # packet ID is only used in server to client - populate with zeros for client to server direction
+            quiet_samples = 0
+            timer = time.time()
+            while quiet_samples < (vox_silence_time * (1 / 0.06)):
+                if time.time() - timer > 30:
+                    print("Timer break")
+                    stop_stream(zello_ws, stream_id)
+                    stream_id = start_stream(zello_ws)
+                    if not stream_id:
+                        print("Cannot start stream")
+                        break
+                    timer = time.time()
+                data2 = data.tobytes()
+                out = opuslib.api.encoder.encode(enc, data2, zello_chunk, len(data2) * 2)
+                send_data = bytearray(np.array([1]).astype(">u1").tobytes())
+                send_data = send_data + np.array([stream_id]).astype(">u4").tobytes()
+                send_data = send_data + np.array([packet_id]).astype(">u4").tobytes()
+                send_data = send_data + out
+                try:
+                    nbytes = zello_ws.send_binary(send_data)
+                    if nbytes == 0:
+                        print("Binary send error")
+                        break
+                except Exception as ex:
+                    print(f"Zello error {ex}")
+                    break
+                data = record(0.06, channel=in_channel_config)
+                max_audio_level = max(abs(data))
+                if max_audio_level < audio_threshold:
+                    quiet_samples = quiet_samples + 1
+                else:
+                    quiet_samples = 0
+            print("Done sending audio")
+            stop_stream(zello_ws, stream_id)
+            zello_ws.close()
+            stream_id = None
+    except KeyboardInterrupt:
+        print("Keyboard interrupt caught")
+        if stream_id:
+            print("Stop sending audio")
+            stop_stream(zello_ws, stream_id)
+            zello_ws.close()
+            stream_id = None
+        processing = False
+
+print("Terminating")
 stream.close()
 p.terminate()

--- a/zellostream.py
+++ b/zellostream.py
@@ -1,9 +1,9 @@
+import sys
 import websocket
 import json
 import time
 import pyaudio
 import numpy as np
-import librosa
 import opuslib
 from Crypto.PublicKey import RSA
 from Crypto.Signature import pkcs1_15
@@ -17,53 +17,58 @@ libgcc_s_sjlj-1.dll
 These can be obtained from the 'opusfile' download at http://opus-codec.org/downloads/
 """
 
-f = open("privatekey.pem", "r")
-key = RSA.import_key(f.read())
-f.close()
-
-with open("config.json") as f:
-    configdata = json.load(f)
-
-username = configdata.get("username")
-if not username:
-    print("ERROR GETTING USERNAME FROM CONFIG FILE")
-password = configdata.get("password")
-if not password:
-    print("ERROR GETTING PASSWORD FROM CONFIG FILE")
-vox_silence_time = configdata.get("vox_silence_time", 3)
-in_channel_config = configdata.get("in_channel", "mono")
-issuer = configdata.get("issuer")
-if not issuer:
-    print("ERROR GETTING ZELLO ISSUER ID FROM CONFIG FILE")
-zello_channel = configdata.get("zello_channel")
-if not zello_channel:
-    print("ERROR GETTING ZELLO CHANNEL NAME FROM CONFIG FILE")
-audio_threshold = configdata.get("audio_threshold", 1000)
-input_device_index = configdata.get("input_device_index", 0)
-audio_sample_rate = configdata.get("audio_sample_rate", 48000)
-zello_sample_rate = configdata.get("audio_sample_rate", 16000)
+seq_num = 0
 
 
-def create_zello_jwt():
+class ConfigException(Exception):
+    pass
+
+
+def get_config():
+    config = {}
+    f = open("privatekey.pem", "r")
+    config["key"] = RSA.import_key(f.read())
+    f.close()
+
+    with open("config.json") as f:
+        configdata = json.load(f)
+
+    username = configdata.get("username")
+    if not username:
+        raise ConfigException("ERROR GETTING USERNAME FROM CONFIG FILE")
+    config["username"] = username
+    password = configdata.get("password")
+    if not password:
+        raise ConfigException("ERROR GETTING PASSWORD FROM CONFIG FILE")
+    config["password"] = password
+    config["vox_silence_time"] = configdata.get("vox_silence_time", 3)
+    config["in_channel_config"] = configdata.get("in_channel", "mono")
+    issuer = configdata.get("issuer")
+    if not issuer:
+        raise ConfigException("ERROR GETTING ZELLO ISSUER ID FROM CONFIG FILE")
+    config["issuer"] = issuer
+    zello_channel = configdata.get("zello_channel")
+    if not zello_channel:
+        raise ConfigException("ERROR GETTING ZELLO CHANNEL NAME FROM CONFIG FILE")
+    config["zello_channel"] = zello_channel
+    config["audio_threshold"] = configdata.get("audio_threshold", 1000)
+    config["input_device_index"] = configdata.get("input_device_index", 0)
+    config["audio_sample_rate"] = configdata.get("audio_sample_rate", 48000)
+    config["audio_channels"] = configdata.get("audio_channels", 1)
+    config["zello_sample_rate"] = configdata.get("audio_sample_rate", 16000)
+    return config
+
+
+def create_zello_jwt(config):
     # Create a Zello-specific JWT.  Can't use PyJWT because Zello doesn't support url safe base64 encoding in the JWT.
     header = {"typ": "JWT", "alg": "RS256"}
-    payload = {"iss": issuer, "exp": round(time.time() + 60)}
-    signer = pkcs1_15.new(key)
+    payload = {"iss": config["issuer"], "exp": round(time.time() + 60)}
+    signer = pkcs1_15.new(config["key"])
     json_header = json.dumps(header, separators=(",", ":"), cls=None).encode("utf-8")
     json_payload = json.dumps(payload, separators=(",", ":"), cls=None).encode("utf-8")
-    h = SHA256.new(
-        base64.standard_b64encode(json_header)
-        + b"."
-        + base64.standard_b64encode(json_payload)
-    )
+    h = SHA256.new(base64.standard_b64encode(json_header) + b"." + base64.standard_b64encode(json_payload))
     signature = signer.sign(h)
-    jwt = (
-        base64.standard_b64encode(json_header)
-        + b"."
-        + base64.standard_b64encode(json_payload)
-        + b"."
-        + base64.standard_b64encode(signature)
-    )
+    jwt = base64.standard_b64encode(json_header) + b"." + base64.standard_b64encode(json_payload) + b"." + base64.standard_b64encode(signature)
     return jwt
 
 
@@ -74,48 +79,46 @@ def EscapeAll(inbytes):
         return "b'{}'".format("".join("\\x{:02x}".format(b) for b in inbytes))
 
 
-print("Start PyAudio")
-p = pyaudio.PyAudio()
-audio_chunk = int(audio_sample_rate * 0.06) # 60ms = 960 samples @ 16000 S/s
-zello_chunk = int(zello_sample_rate * 0.06)
-FORMAT = pyaudio.paInt16
-CHANNELS = 1
-print("Open audio")
-stream = p.open(
-    format=FORMAT,
-    channels=CHANNELS,
-    rate=audio_sample_rate,
-    input=True,
-    output=True,
-    frames_per_buffer=audio_chunk,
-    input_device_index=input_device_index,
-)
-print("Audio opened")
+def start_audio(config, p):
+    audio_chunk = int(config["audio_sample_rate"] * 0.06)  # 60ms = 960 samples @ 16000 S/s
+    format = pyaudio.paInt16
+    print("start_audio: open audio")
+    stream = p.open(
+        format=format,
+        channels=config["audio_channels"],
+        rate=config["audio_sample_rate"],
+        input=True,
+        output=True,
+        frames_per_buffer=audio_chunk,
+        input_device_index=config["input_device_index"],
+    )
+    print("start_audio: audio opened")
+    return stream
 
 
-def record(seconds, channel="mono"):
+def record(config, stream, seconds, channel="mono"):
     alldata = bytearray()
-    for i in range(0, int(audio_sample_rate / audio_chunk * seconds)):
+    audio_chunk = int(config["audio_sample_rate"] * 0.06)
+    for i in range(0, int(config["audio_sample_rate"] / audio_chunk * seconds)):
         data = stream.read(audio_chunk)
         alldata.extend(data)
     data = np.frombuffer(alldata, dtype=np.short)
-    if audio_sample_rate != zello_sample_rate:
-        zello_data = librosa.resample(data, audio_sample_rate, zello_sample_rate)
+    if config["audio_sample_rate"] != config["zello_sample_rate"]:
+        zello_data = librosa.resample(data, config["audio_sample_rate"], config["zello_sample_rate"])
     else:
         zello_data = data
     if channel == "left":
         zello_data = zello_data[0::2]
     elif channel == "right":
         zello_data = zello_data[1::2]
+    elif channel == "mix":
+        zello_data = (zello_data[0::2] + zello_data[1::2]) / 2
     else:
         zello_data = zello_data
     return zello_data
 
 
-seq_num = 0
-
-
-def create_zello_connection():
+def create_zello_connection(config):
     try:
         ws = websocket.create_connection("wss://zello.io/ws")
         ws.settimeout(1)
@@ -124,11 +127,11 @@ def create_zello_connection():
         send = {}
         send["command"] = "logon"
         send["seq"] = seq_num
-        encoded_jwt = create_zello_jwt()
+        encoded_jwt = create_zello_jwt(config)
         send["auth_token"] = encoded_jwt.decode("utf-8")
-        send["username"] = username
-        send["password"] = password
-        send["channel"] = zello_channel
+        send["username"] = config["username"]
+        send["password"] = config["password"]
+        send["channel"] = config["zello_channel"]
         ws.send(json.dumps(send))
         result = ws.recv()
         data = json.loads(result)
@@ -140,11 +143,12 @@ def create_zello_connection():
         return None
 
 
-def start_stream(ws):
+def start_stream(config, ws):
     global seq_num
+    start_seq_num = seq_num
     send = {}
     send["command"] = "start_stream"
-    send["channel"] = zello_channel
+    send["channel"] = config["zello_channel"]
     send["seq"] = seq_num
     seq_num = seq_num + 1
     send["type"] = "audio"
@@ -154,7 +158,9 @@ def start_stream(ws):
     # gd4BPA==  => 0x80 0x3e 0x01 0x3c  => 16000 Hz, 1 frame per packet, 60 ms frame size
     frames_per_packet = 1
     packet_duration = 60
-    codec_header = base64.b64encode(zello_sample_rate.to_bytes(2, "little") + frames_per_packet.to_bytes(1, "big") + packet_duration.to_bytes(1, "big")).decode()
+    codec_header = base64.b64encode(
+        config["zello_sample_rate"].to_bytes(2, "little") + frames_per_packet.to_bytes(1, "big") + packet_duration.to_bytes(1, "big")
+    ).decode()
     send["codec_header"] = codec_header
     send["packet_duration"] = packet_duration
     try:
@@ -168,7 +174,7 @@ def start_stream(ws):
             print("start_stream: data:", data)
             if "error" in data.keys():
                 print("start_stream: error", data["error"])
-                if seq_num > 10:
+                if seq_num > start_seq_num + 8:
                     print("start_stream: bailing out")
                     return None
                 time.sleep(0.5)
@@ -180,7 +186,7 @@ def start_stream(ws):
                 return stream_id
         except Exception as ex:
             print(f"start_stream: exception {ex}")
-            if seq_num > 10:
+            if seq_num > start_seq_num + 8:
                 print("start_stream: bailing out")
                 return None
             time.sleep(0.5)
@@ -203,76 +209,97 @@ def stop_stream(ws, stream_id):
         print(f"stop_stream: exception: {ex}")
 
 
-enc = opuslib.api.encoder.create_state(
-    zello_sample_rate, CHANNELS, opuslib.APPLICATION_AUDIO
-)
+def create_encoder(config):
+    return opuslib.api.encoder.create_state(config["zello_sample_rate"], config["audio_channels"], opuslib.APPLICATION_AUDIO)
 
-stream_id = None
-processing = True
 
-while processing:
+def main():
     try:
-        data = record(seconds=0.06, channel=in_channel_config)
-        max_audio_level = max(abs(data))
-        # print(f"Init max_audio_level: {max_audio_level}")
-        if max_audio_level > audio_threshold:
-            print("Audio on")
-            zello_ws = create_zello_connection()
-            if not zello_ws:
-                print("Cannot establish connection")
-                time.sleep(1)
-                continue
-            stream_id = start_stream(zello_ws)
-            if not stream_id:
-                print("Cannot start stream")
-                time.sleep(1)
-                continue
-            print("sending to stream_id " + str(stream_id))
-            packet_id = 0 # packet ID is only used in server to client - populate with zeros for client to server direction
-            quiet_samples = 0
-            timer = time.time()
-            while quiet_samples < (vox_silence_time * (1 / 0.06)):
-                if time.time() - timer > 30:
-                    print("Timer break")
-                    stop_stream(zello_ws, stream_id)
-                    stream_id = start_stream(zello_ws)
-                    if not stream_id:
-                        print("Cannot start stream")
-                        break
-                    timer = time.time()
-                data2 = data.tobytes()
-                out = opuslib.api.encoder.encode(enc, data2, zello_chunk, len(data2) * 2)
-                send_data = bytearray(np.array([1]).astype(">u1").tobytes())
-                send_data = send_data + np.array([stream_id]).astype(">u4").tobytes()
-                send_data = send_data + np.array([packet_id]).astype(">u4").tobytes()
-                send_data = send_data + out
-                try:
-                    nbytes = zello_ws.send_binary(send_data)
-                    if nbytes == 0:
-                        print("Binary send error")
-                        break
-                except Exception as ex:
-                    print(f"Zello error {ex}")
-                    break
-                data = record(0.06, channel=in_channel_config)
-                max_audio_level = max(abs(data))
-                if max_audio_level < audio_threshold:
-                    quiet_samples = quiet_samples + 1
-                else:
-                    quiet_samples = 0
-            print("Done sending audio")
-            stop_stream(zello_ws, stream_id)
-            zello_ws.close()
-            stream_id = None
-    except KeyboardInterrupt:
-        print("Keyboard interrupt caught")
-        if stream_id:
-            print("Stop sending audio")
-            stop_stream(zello_ws, stream_id)
-            zello_ws.close()
-            stream_id = None
-        processing = False
+        config = get_config()
+    except ConfigException as ex:
+        print(f"Configuration error: {ex}")
+        sys.exit(1)
 
-print("Terminating")
-stream.close()
-p.terminate()
+    print("Importing librosa...")
+    import librosa
+    print("Imported librosa")
+    print("Start PyAudio")
+    p = pyaudio.PyAudio()
+    print("Started PyAudio")
+    audio_stream = start_audio(config, p)
+    zello_chunk = int(config["zello_sample_rate"] * 0.06)
+    enc = create_encoder(config)
+
+    stream_id = None
+    processing = True
+
+    while processing:
+        try:
+            data = record(config, audio_stream, seconds=0.06, channel=config["in_channel_config"])
+            max_audio_level = max(abs(data))
+            # print(f"Init max_audio_level: {max_audio_level}")
+            if max_audio_level > config["audio_threshold"]:
+                print("Audio on")
+                zello_ws = create_zello_connection(config)
+                if not zello_ws:
+                    print("Cannot establish connection")
+                    time.sleep(1)
+                    continue
+                stream_id = start_stream(config, zello_ws)
+                if not stream_id:
+                    print("Cannot start stream")
+                    time.sleep(1)
+                    continue
+                print("sending to stream_id " + str(stream_id))
+                packet_id = 0  # packet ID is only used in server to client - populate with zeros for client to server direction
+                quiet_samples = 0
+                timer = time.time()
+                while quiet_samples < (config["vox_silence_time"] * (1 / 0.06)):
+                    if time.time() - timer > 30:
+                        print("Timer break")
+                        stop_stream(zello_ws, stream_id)
+                        stream_id = start_stream(config, zello_ws)
+                        if not stream_id:
+                            print("Cannot start stream")
+                            break
+                        timer = time.time()
+                    data2 = data.tobytes()
+                    out = opuslib.api.encoder.encode(enc, data2, zello_chunk, len(data2) * 2)
+                    send_data = bytearray(np.array([1]).astype(">u1").tobytes())
+                    send_data = send_data + np.array([stream_id]).astype(">u4").tobytes()
+                    send_data = send_data + np.array([packet_id]).astype(">u4").tobytes()
+                    send_data = send_data + out
+                    try:
+                        nbytes = zello_ws.send_binary(send_data)
+                        if nbytes == 0:
+                            print("Binary send error")
+                            break
+                    except Exception as ex:
+                        print(f"Zello error {ex}")
+                        break
+                    data = record(config, audio_stream, 0.06, channel=config["in_channel_config"])
+                    max_audio_level = max(abs(data))
+                    if max_audio_level < config["audio_threshold"]:
+                        quiet_samples = quiet_samples + 1
+                    else:
+                        quiet_samples = 0
+                print("Done sending audio")
+                stop_stream(zello_ws, stream_id)
+                zello_ws.close()
+                stream_id = None
+        except KeyboardInterrupt:
+            print("Keyboard interrupt caught")
+            if stream_id:
+                print("Stop sending audio")
+                stop_stream(zello_ws, stream_id)
+                zello_ws.close()
+                stream_id = None
+            processing = False
+
+    print("Terminating")
+    audio_stream.close()
+    p.terminate()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR covers a number of fixes making it more robust when errors and exceptions are returned from the Zello server. It may correct #9 and #8. It does not matter so much if some audio frames are dropped as long as the program does not crash because you would like to run it unattended for a long time.

It also changes some constructs in a more "pythonic" way in particular it uses a "main" function.

It adds the possibility to have an audio sample rate different from the sample rate used in the stream sent to Zello which is generally the case (48k vs 16k). In order to do this it uses the librosa resampling library. This library takes some time to initialize therefore its import is enclosed between prints to the console in the main() function so that the user knows that the program is not dead right at the start. Also concerning audio it adds the possibility to choose the number of channels thus having 2 for stereo devices which is generally the case. Consequently it also adds "mix" to the list of possible "in_channel_config" options. 