### PR TITLE
Added ZelloWork Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ For Zello consumer network:
 - TGID_in_stream: Only used when audio_source is set to "UDP". When true, a four-byte talkgroup ID is expected prior to the audio data in each incoming UDP packet and only the talkgroup specified in TGID_to_play will be streamed.  Default is false.
 - TGID_to_play: Only used when audio_source is set to "UDP". When TGID_in_stream is set to true, the integer in this field specifies which talkgroup ID will be streamed. Default 70000
 - UDP_PORT: Only used when audio_source is set to "UDP". UDP port to listen for oncompressed PCM audio on.  Audio received on this port will be compressed and streamed to Zello. Default 9123
+- zello_work_account_name: Use only when streaming to a ZelloWork account. Include just the zellowork subdomain name here. If you access your zello work account at https://zellostream.zellowork.com, your subdomain would just be zellowork. If left blank, the public zello network will be used.
 
 ## Dependencies
 ### Windows

--- a/zellostream.py
+++ b/zellostream.py
@@ -86,6 +86,12 @@ def get_config():
 	config["udp_port"] = configdata.get("UDP_PORT",9123)
 	config["tgid_in_stream"] = configdata.get("TGID_in_stream",False)
 	config["tgid_to_play"] = configdata.get("TGID_to_play",70000)
+	zello_work = configdata.get("zello_work_account_name")
+	if zello_work:
+		config["zello_ws_url"] = "wss://zellowork.io/ws/" + zello_work
+	else:
+		config["zello_ws_url"] = "wss://zello.io/ws"
+
 	return config
 
 
@@ -277,7 +283,7 @@ def get_udp_audio(config,seconds,channel="mono"):
 
 def create_zello_connection(config):
 	try:
-		ws = websocket.create_connection("wss://zello.io/ws")
+		ws = websocket.create_connection(config["zello_ws_url"])
 		ws.settimeout(1)
 		global seq_num
 		seq_num = 1

--- a/zellostreamUDP.py
+++ b/zellostreamUDP.py
@@ -74,7 +74,12 @@ try:
 	audio_sample_rate = configdata['audio_sample_rate']
 except:
 	audio_sample_rate = 8000
-	
+try:
+	zello_ws_url = "wss://zellowork.io/ws/" + configdata['zello_work_account_name']
+except:
+	zello_ws_url = "wss://zello.io/ws"
+print("Zello URL is ", zello_ws_url)
+
 # Set up a UDP server to receive audio from trunk-recorder
 UDPSock = socket.socket(socket.AF_INET,socket.SOCK_DGRAM)
 UDPSock.settimeout(.5)
@@ -102,7 +107,7 @@ def EscapeAll(inbytes):
 
 seq_num = 0
 def create_zello_connection():
-	ws = websocket.create_connection("wss://zello.io/ws")
+	ws = websocket.create_connection(zello_ws_url)
 	ws.settimeout(1)
 	global seq_num
 	seq_num = 1


### PR DESCRIPTION
This addresses issue #3 

I have tested the Zellowork side of this PR in both scripts and websockets successfully connect. I'm not setup to test the public network in depth but can confirm the correct outbound request is made to the public network URL. On the zellowork side I've been running this code for ~2 weeks without issue on a few mototrbo deployments.

This PR adds the configuration option: "zello_work_account_name" If blank or not set, this defaults to the public URL, if set with the account/subdomain, it connects to that deployment.


